### PR TITLE
removed ?page= per briandfoy issue 122

### DIFF
--- a/content/legacy/_pub_2005_08_25_tools.md
+++ b/content/legacy/_pub_2005_08_25_tools.md
@@ -62,15 +62,15 @@ A great Perl IDE will contain at least the following, plus other features I have
 -   A [syntax-coloring text editor.](#Syntax-coloring_text_editor)
 -   [Real-time syntax-checking](#Syntax-checking) to catch and display syntax errors as you type.
 -   [Version control integration](#Version_control_integration) to check out and compare code using CVS, Subversion, etc.
--   A [code-assist editor](?page=3#Code-assist), to provide a list of methods when you type in an object reference, for example.
--   [Excellent refactoring support](?page=3#refactoring_support).
--   A [tree view of source files and resources](?page=4#Tree_view_of_source).
--   [Support for creating and running unit tests](?page=4#support_for_unit_tests).
--   [Language-specific help](?page=5#Language-specific_help).
--   [Real-time display of debugging results](?page=5#Debugger).
--   [Automatic code reformatting](?page=5#Automatic_reformatting).
--   Seamless [handling of multiple languages](?page=5#handling_of_multiple_languages) (such as Perl and C, Perl and Java, Perl and PHP, or Perl and Python).
--   [Automated build and test support](?page=5#Automated_build_and_test).
+-   A [code-assist editor](#Code-assist), to provide a list of methods when you type in an object reference, for example.
+-   [Excellent refactoring support](#refactoring_support).
+-   A [tree view of source files and resources](#Tree_view_of_source).
+-   [Support for creating and running unit tests](#support_for_unit_tests).
+-   [Language-specific help](#Language-specific_help).
+-   [Real-time display of debugging results](#Debugger).
+-   [Automatic code reformatting](#Automatic_reformatting).
+-   Seamless [handling of multiple languages](#handling_of_multiple_languages) (such as Perl and C, Perl and Java, Perl and PHP, or Perl and Python).
+-   [Automated build and test support](#Automated_build_and_test).
 
 Most of the screen shot examples in this article use the EPIC Perl IDE. At present, it has the largest amount of the features on my list (although it certainly doesn't have all of them).
 


### PR DESCRIPTION
Per https://github.com/tpf/perldotcom/issues/122, I searched for ?page= in content/legacy, found [this page](https://www.perl.com/pub/2005/08/25/tools.html/), checked to see if the anchors were set without the page, and removed the page= from the links.