### PR TITLE
Start using CODEOWNERS to review pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @dnmfarrell @briandfoy


### PR DESCRIPTION
We can require reviewers to merge to master. 

The main advantage is that the names of the reviewers show up near the top of the pull request. People can see who they are waiting on to make things happen.