### PR TITLE
Fix for #194 Ensure list of latest articles have an authors param defined

### DIFF
--- a/layouts/partials/latest-sidebar.html
+++ b/layouts/partials/latest-sidebar.html
@@ -5,7 +5,7 @@
       <span style="font-size:1.8em" class="antonio txt-blue-major">OUR LATEST ARTICLES</span>
     </div>
   </div>
-  {{ range first 5 .Site.Pages }}
+  {{ range first 5 (where .Site.Pages ".Params.authors" "!=" nil) }}
     {{ $author_name := index .Params.authors 0 }}
     {{ $author := index $authors $author_name }}
     <div class="row">


### PR DESCRIPTION
.Site.Pages was returning pages without an author defined which caused the build of `layouts/partials/latest-sidebar.html` to fail.  Something must have changed in the way they generate the list of pages.  I have added filtering to the list so it returns the 5 latest pages that also have an `authors` parameter defined.

Fixed issue #194 