### PR TITLE
Permit authors to specify "their" value used in bio for "Browse their articles"

### DIFF
--- a/data/author/christopher-white.json
+++ b/data/author/christopher-white.json
@@ -2,5 +2,6 @@
   "name": "Christopher White",
   "key": "christopher-white",
   "bio": "Chris White is an experienced and productive inventor, public speaker, patent agent, computer engineer, demoscener, and software developer.  He is currently building embedded Linux systems for D3 Engineering.  He intermittently [blogs](http://devwrench.com) about technology, music, and cheese.",
-  "image": "/images/author/christopher-white.jpg"
+  "image": "/images/author/christopher-white.jpg",
+  "their": "his"
 }

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -2,11 +2,11 @@
 <div class="row" id="author-bio-{{ $author.key }}">
   <div class="col-sm-2">
     {{ $avatar_uri := or $author.image "/images/avatar.png" }}
-    <a href="/authors/{{ $author.key }}"><div class="circle-avatar" style="background-image:url({{ $avatar_uri }})"></div></a>
+    <a href="/authors/{{ $author.key }}/"><div class="circle-avatar" style="background-image:url({{ $avatar_uri }})"></div></a>
   </div>
   <div class="col-sm-10">
-    <a href="/authors/{{ $author.key }}"><h3>{{ $author.name }}</h3></a>
+    <a href="/authors/{{ $author.key }}/"><h3>{{ $author.name }}</h3></a>
     <p>{{ or $author.bio "" | markdownify }}</p>
-    <h5><a href="/authors/{{ $author.key }}">Browse their articles</a></h5>
+    <h5><a href="/authors/{{ $author.key }}/">Browse {{ (or $author.their "their") | html }} articles</a></h5>
   </div>
 </div>


### PR DESCRIPTION
### Main change

Bios currently say "Browse their articles".  With this PR, authors can add a "their" key to their author data to change "Browse their articles" to "Browse `$their` articles".

Also adds the "their" key to yours truly's bio in order to provide a meaningful test case.

Closes #216.

### Author links

While testing locally, I got `not found` on `/authors/foo`.  Turns out the live site redirects those - `https://perl.com/author/foo` -> `http` (!) `://perl.com/author/foo/` -> `https://perl.com/author/foo/`.  

![image](https://user-images.githubusercontent.com/10515894/73129371-1063ee80-3fb0-11ea-9311-f6d0e21524ca.png)

In this PR, I changed the links to author pages to end with a trailing slash.  This makes those links functional when testing locally with Plack::App::File, and should remove those redirects on the live site.

