### PR TITLE
Require valid UTF-8 in title and description, and decode.

### DIFF
--- a/bin/new-article
+++ b/bin/new-article
@@ -55,6 +55,9 @@ open my $fh, '>:utf8', $filename;
 my $dt = localtime;
 my $date = $dt->datetime;
 
+utf8::decode($title) or die "Title must be valid UTF-8.\n";
+utf8::decode($description) or die "Description must be valid UTF-8.\n";
+
 print $fh qq(
   {
     "title"       : "$title",


### PR DESCRIPTION
This prevents mojibake in the output if the given title and/or description uses UTF-8. For example:
```
  {
    "title"       : "JSON, Unicode, and Perl â¦ Oh My!",
    "authors"     : ["felipe-gasper"],
    "date"        : "2020-01-27T07:11:44",
    "tags"        : [],
    "draft"       : true,
    "image"       : "",
    "thumbnail"   : "",
    "description" : "A look at this popular serializationâs relationship with Perl",
    "categories"  : "development"
  }
```