### PR TITLE
Allow command line to be in non-UTF-8 encodings

### DIFF
--- a/bin/new-article
+++ b/bin/new-article
@@ -1,11 +1,15 @@
 #!/usr/bin/env perl
 use v5.10;
 use autodie;
+use open qw(:std :utf8);
+
 use Cwd;
+use Encode;
 use ExtUtils::MakeMaker qw(prompt);
 use File::Basename qw(basename);
 use File::Spec::Functions qw(catfile);
 use Getopt::Long 'GetOptions';
+use I18N::Langinfo qw(langinfo CODESET);
 use IO::Interactive qw(is_interactive);
 use Time::Piece;
 
@@ -44,6 +48,10 @@ if( is_interactive ) {
 
 usage() unless $title && $author && $category && (grep $_ eq $category, @categories);
 
+# don't assume that the command line is a particular encoding. See what
+# CODESET is and decode it into a Perl string.
+( $title, $description, $author, $category ) = map { decode( langinfo(CODESET), $_ ) }
+	( $title, $description, $author, $category );
 
 # prepare the file
 my $filename = lc $title;
@@ -54,9 +62,6 @@ open my $fh, '>:utf8', $filename;
 
 my $dt = localtime;
 my $date = $dt->datetime;
-
-utf8::decode($title) or die "Title must be valid UTF-8.\n";
-utf8::decode($description) or die "Description must be valid UTF-8.\n";
 
 print $fh qq(
   {


### PR DESCRIPTION
See if you like this command-line argument decoder better. It doesn't assume it knows what the input encoding is.