### PR TITLE
Link to the GitHub issue for nixing module's return value

### DIFF
--- a/content/article/patching-perl-loading-modules-that-return-false.md
+++ b/content/article/patching-perl-loading-modules-that-return-false.md
@@ -11,6 +11,8 @@
     "categories"  : "perl-internals"
   }
 
+[**Update**: this is now [an issue for Perl 7](https://github.com/Perl/perl5/issues/17921)]
+
 If you've been programming Perl for a while, you've probably run into this exception: `Foo.pm did not return a true value`. This is a peculiar quirk of the `require` function: modules *must* return a true value else Perl interprets it as a failure:
 
 > The file must return true as the last statement to indicate


### PR DESCRIPTION
David's article on the return value for modules in now an issue in Perl's GitHub, so I added an update line. I don't particularly care how the update is included.