### PR TITLE
Adjust page margins

### DIFF
--- a/static/css/perldotcom.css
+++ b/static/css/perldotcom.css
@@ -296,6 +296,10 @@ code.language-prettyprint .dec { color: #98fb98 } /* decimal         - lightgree
   #search {
     display: block;
   }
+  .container {
+    margin-left:9.5px;
+    margin-right:9.5px;
+  }
 }
 
 /* toplinks widget styling */


### PR DESCRIPTION
Media widths below 768px result in no padding on the `#content section.entry-content div.container` element.
The 9.5px value is also the padding applied to `<pre>` elements, which seems reasonable.

An absolute value between 5px and 15px may be appropriate, or 0.5 to 2%?

The footer content has a left margin defined as 20px, which may be too much for the article content itself.

NB I believe #243 is not iOS specific - I witness the same in Chrome on Android.