### PR TITLE
Spelling

### DIFF
--- a/bin/check_links
+++ b/bin/check_links
@@ -60,7 +60,7 @@ The maximum number of concurrent requests (default: 4)
 
 =item --report
 
-Show a consoldated report of bad links at the end (default: Off)
+Show a consolidated report of bad links at the end (default: Off)
 
 =item --verbose
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,7 +34,7 @@ ga('editor.send', 'pageview');
 <body>
 <!-- NAVBAR
 ================================================== -->
-<div class="container-fluid full-wdith antonio">
+<div class="container-fluid full-width antonio">
  <div class="row">
   <div class="navbar-inverse" style="border-radius:none !important" role="navigation">
     <div class="container-fluid">

--- a/lib/Local/Metadata.pm
+++ b/lib/Local/Metadata.pm
@@ -334,7 +334,7 @@ sub augment( $self, @args ) {
 
 =head1 SOURCE AVAILABILITY
 
-This module is on Github:
+This module is on GitHub:
 
 	https://github.com/tpf/perldotcom
 

--- a/lib/Local/Metadata.pm
+++ b/lib/Local/Metadata.pm
@@ -127,7 +127,7 @@ sub _extract_metadata_from_md ( $class, $filename ) {
 =item * is_published
 
 Returns true if the article is not a draft (which means it is handled
-by Hugo and visibile on the site)
+by Hugo and visible on the site)
 
 =item * is_draft
 

--- a/static/css/perldotcom.css
+++ b/static/css/perldotcom.css
@@ -154,7 +154,7 @@ div.circle-avatar{
   /* Centering on image`s center*/
   background-position: center;
   background-repeat: no-repeat;
-  /* it makes the clue thing, takes smaller dimention to fill div */
+  /* it makes the clue thing, takes smaller dimension to fill div */
   background-size: cover;
 }
 /* footer */


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/perldotcom/commit/9b0957b9b30ba23014480006ac20ae7f22bdb498#commitcomment-47959536

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/perldotcom/commit/f13a323669863544a8359fff19b1d98c380862a1

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

---

I've intentionally excluded the articles as they appear to often include old versions of CPAN modules that in turn have typos.

Random example of typos in articles:
* [ballon (sic)](https://github.com/tpf/perldotcom/search?q=ballon)