### PR TITLE
Fixed code example for ternary operator

### DIFF
--- a/content/article/the-conditional--ternary--operator.md
+++ b/content/article/the-conditional--ternary--operator.md
@@ -23,14 +23,12 @@ Let's convert a standard Perl if-else into its conditional operator equivalent, 
 ```perl
 sub calculate_salary {
     my $hours = shift;
-    my $salary;
     if ($hours > 40) {
-        $salary = get_overtime_wage($hours);
+        return get_overtime_wage($hours);
     }
     else {
-        $salary = get_normal_wage($hours);
+        return get_normal_wage($hours);
     }
-    return $salary;
 }
 ```
 


### PR DESCRIPTION
The code example for standard if-else was not really equivalent to the example where the ternary operator was used. The additional `$salary` variable is not needed.

If you like this PR I'd be happy if you would merge it or label it with [`hacktoberfest-accepted`](https://hacktoberfest.com/participation/). Thanks in advance.